### PR TITLE
商品一覧表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
   def index
-    @items = Item.all
+    @items = Item.all.order("created_at DESC")
   end
 
   def new

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,4 +2,9 @@ class ItemsController < ApplicationController
   def index
     @items = Item.all
   end
+
+  def new
+    @item = Item.new
+  end
+  
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -6,4 +6,11 @@ class Item < ApplicationRecord
   belongs_to_active_hash :shipping_charge
   belongs_to_active_hash :shipping_area
   belongs_to_active_hash :shipping_day
+
+  validates :name, :image, :detail, :category_id,
+            :status_id, :shipping_charge_id, :shipping_area_id,
+            :shipping_day_id, :selling_price, presence: true
+
+  validates :category_id, :status_id, :shipping_charge_id,
+            :shipping_area_id, :shipping_day_id, numericality: { other_than: 1 }
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,5 +1,6 @@
 class Item < ApplicationRecord
   extend ActiveHash::Associations::ActiveRecordExtensions
+  belongs_to :user
   belongs_to_active_hash :category
   belongs_to_active_hash :status
   belongs_to_active_hash :shipping_charge

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,0 +1,3 @@
+class User < ApplicationRecord
+  has_many :items
+end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -131,7 +131,7 @@
         <li class='list'>
           <%= link_to "#" do %>
           <div class='item-img-content'>
-            <%= image_tag "item-sample.png", class: "item-img" %>
+            <%= image_tag item.image, class: "item-img" %>
 
             <%# 商品が売れていればsold outの表示 %>
             <div class='sold-out'>
@@ -145,7 +145,7 @@
               <%= item.name %>
             </h3>
             <div class='item-price'>
-              <span><%= "販売価格" %>円<br>(税込み)</span>
+              <span><%= item.selling_price %>円<br>(税込み)</span>
               <div class='star-btn'>
                 <%= image_tag "star.png", class:"star-icon" %>
                 <span class='star-count'>0</span>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -123,7 +123,7 @@
   <%# 商品一覧 %>
   <div class='item-contents'>
     <h2 class='title'>ピックアップカテゴリー</h2>
-    <%= link_to '新規投稿商品', "#", class: "subtitle" %>
+    <%= link_to '新規投稿商品', "/items/new", class: "subtitle" %>
     <ul class='item-lists'>
 
       <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
@@ -182,7 +182,7 @@
 </div>
 <div class='purchase-btn'>
   <span class='purchase-btn-text'>出品する</span>
-  <a href="#">
+  <a href="/items/new">
     <%= image_tag 'camera.png' , size: '185x50' ,class: "purchase-btn-icon" %>
   </a>
 </div>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -159,23 +159,25 @@
 
       <%# 商品がない場合のダミー %>
       <%# 商品がある場合は表示されないようにしましょう %>
-      <li class='list'>
-        <%= link_to '#' do %>
-        <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %>
-        <div class='item-info'>
-          <h3 class='item-name'>
-            商品を出品してね！
-          </h3>
-          <div class='item-price'>
-            <span>99999999円<br>(税込み)</span>
-            <div class='star-btn'>
-              <%= image_tag "star.png", class:"star-icon" %>
-              <span class='star-count'>0</span>
+      <% if @items.blank? %>
+        <li class='list'>
+          <%= link_to '#' do %>
+          <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %>
+          <div class='item-info'>
+            <h3 class='item-name'>
+              商品を出品してね！
+            </h3>
+            <div class='item-price'>
+              <span>99999999円<br>(税込み)</span>
+              <div class='star-btn'>
+                <%= image_tag "star.png", class:"star-icon" %>
+                <span class='star-count'>0</span>
+              </div>
             </div>
           </div>
-        </div>
-        <% end %>
-      </li>
+          <% end %>
+        </li>
+      <% end %>
       <%# //商品がある場合は表示されないようにしましょう %>
       <%# //商品がない場合のダミー %>
     </ul>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -127,32 +127,34 @@
     <ul class='item-lists'>
 
       <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-      <li class='list'>
-        <%= link_to "#" do %>
-        <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
+      <% @items.each do |item|%>
+        <li class='list'>
+          <%= link_to "#" do %>
+          <div class='item-img-content'>
+            <%= image_tag "item-sample.png", class: "item-img" %>
 
-          <%# 商品が売れていればsold outの表示 %>
-          <div class='sold-out'>
-            <span>Sold Out!!</span>
+            <%# 商品が売れていればsold outの表示 %>
+            <div class='sold-out'>
+              <span>Sold Out!!</span>
+            </div>
+            <%# //商品が売れていればsold outの表示 %>
+
           </div>
-          <%# //商品が売れていればsold outの表示 %>
-
-        </div>
-        <div class='item-info'>
-          <h3 class='item-name'>
-            <%= "商品名" %>
-          </h3>
-          <div class='item-price'>
-            <span><%= "販売価格" %>円<br>(税込み)</span>
-            <div class='star-btn'>
-              <%= image_tag "star.png", class:"star-icon" %>
-              <span class='star-count'>0</span>
+          <div class='item-info'>
+            <h3 class='item-name'>
+              <%= item.name %>
+            </h3>
+            <div class='item-price'>
+              <span><%= "販売価格" %>円<br>(税込み)</span>
+              <div class='star-btn'>
+                <%= image_tag "star.png", class:"star-icon" %>
+                <span class='star-count'>0</span>
+              </div>
             </div>
           </div>
-        </div>
-        <% end %>
-      </li>
+          <% end %>
+        </li>
+      <% end %>
       <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
 
       <%# 商品がない場合のダミー %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,4 @@
 Rails.application.routes.draw do
   root to: "items#index"
+  resources :items, only: [:index, :new]
 end

--- a/db/migrate/20200829024930_create_items.rb
+++ b/db/migrate/20200829024930_create_items.rb
@@ -1,16 +1,16 @@
 class CreateItems < ActiveRecord::Migration[6.0]
   def change
     create_table :items do |t|
-      t.integer :user_id
-      t.string :name
-      t.string :image
-      t.text :detail
-      t.integer :category_id
-      t.integer :status_id
-      t.integer :shipping_charge_id
-      t.integer :shipping_area_id
-      t.integer :shipping_day_id
-      t.integer :selling_price
+      t.integer :user_id, null: false, foreign_key: true
+      t.string :name, null: false
+      t.string :image, null: false
+      t.text :detail, null: false
+      t.integer :category_id, null: false
+      t.integer :status_id, null: false
+      t.integer :shipping_charge_id, null: false
+      t.integer :shipping_area_id, null: false
+      t.integer :shipping_day_id, null: false
+      t.integer :selling_price, null: false
       t.timestamps
     end
   end

--- a/db/migrate/20200829060721_create_users.rb
+++ b/db/migrate/20200829060721_create_users.rb
@@ -1,0 +1,15 @@
+class CreateUsers < ActiveRecord::Migration[6.0]
+  def change
+    create_table :users do |t|
+      t.string :nickname
+      t.string :email
+      t.string :password
+      t.string :first_name
+      t.string :last_name
+      t.string :first_name_kana
+      t.string :last_name_kana
+      t.date :date_of_birth
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_29_024930) do
+ActiveRecord::Schema.define(version: 2020_08_29_060721) do
 
   create_table "items", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "user_id"
@@ -23,6 +23,19 @@ ActiveRecord::Schema.define(version: 2020_08_29_024930) do
     t.integer "shipping_area_id"
     t.integer "shipping_day_id"
     t.integer "selling_price"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "nickname"
+    t.string "email"
+    t.string "password"
+    t.string "first_name"
+    t.string "last_name"
+    t.string "first_name_kana"
+    t.string "last_name_kana"
+    t.date "date_of_birth"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -13,16 +13,16 @@
 ActiveRecord::Schema.define(version: 2020_08_29_060721) do
 
   create_table "items", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.integer "user_id"
-    t.string "name"
-    t.string "image"
-    t.text "detail"
-    t.integer "category_id"
-    t.integer "status_id"
-    t.integer "shipping_charge_id"
-    t.integer "shipping_area_id"
-    t.integer "shipping_day_id"
-    t.integer "selling_price"
+    t.integer "user_id", null: false
+    t.string "name", null: false
+    t.string "image", null: false
+    t.text "detail", null: false
+    t.integer "category_id", null: false
+    t.integer "status_id", null: false
+    t.integer "shipping_charge_id", null: false
+    t.integer "shipping_area_id", null: false
+    t.integer "shipping_day_id", null: false
+    t.integer "selling_price", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class UserTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
商品一覧表示機能を実装しました。
商品出品機能が別であることを後で知り、余分で追加してしまっている部分もあります。

What・Why
ユーザー情報が保存できるように、userモデルとテーブルを作成しました。  
新規投稿商品画面への遷移をするために、ルーティングの設定、controllerにnewアクションを設定し、ビューファイルから遷移できるように、ボタンへのURL設定をしました。  
各商品名、画像を表示できるように、eachメソッドを導入しました。  
もし商品情報がなかったとき用のダミー画像は、if @items.blank?　と記載して、空の場合はダミー画像が表示されるようにしました。 
orderメソッドを使って、降順に表示されるようにしています。

現在の画面のGyazoです。
https://gyazo.com/817f793e464ce20216e55c03dd4b9f24

よろしくお願いします。